### PR TITLE
pass `options` to `it` within `run_spec`

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,14 @@ If you've used [Swagger](http://swagger.io/specification) before, then the synta
 
 Take special note of the __run_test!__ method that's called within each response block. This tells rswag to create and execute a corresponding example. It builds and submits a request based on parameter descriptions and corresponding values that have been provided using the rspec "let" syntax. For example, the "post" description in the example above specifies a "body" parameter called "blog". It also lists 2 different responses. For the success case (i.e. the 201 response), notice how "let" is used to set the blog parameter to a value that matches the provided schema. For the failure case (i.e. the 422 response), notice how it's set to a value that does not match the provided schema. When the test is executed, rswag also validates the actual response code and, where applicable, the response body against the provided [JSON Schema](http://json-schema.org/documentation.html).
 
+If you want to add metadata to the example, you can pass keyword arguments to the __run_test!__ method:
+
+```ruby
+response '201', 'blog created' do
+  run_test! focus: true
+end
+```
+
 If you want to do additional validation on the response, pass a block to the __run_test!__ method:
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -192,8 +192,14 @@ Take special note of the __run_test!__ method that's called within each response
 If you want to add metadata to the example, you can pass keyword arguments to the __run_test!__ method:
 
 ```ruby
+# to run particular test case
 response '201', 'blog created' do
   run_test! focus: true
+end
+
+# to write vcr cassette
+response '201', 'blog created' do
+  run_test! vcr: true
 end
 ```
 

--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -122,14 +122,16 @@ module Rswag
       # @param &block [Proc] you can make additional assertions within that block
       # @return [void]
       def run_test!(**options, &block)
+        options[:rswag] = true unless options.key?(:rswag)
+
         if RSPEC_VERSION < 3
           ActiveSupport::Deprecation.warn('Rswag::Specs: WARNING: Support for RSpec 2.X will be dropped in v3.0')
           before do
             submit_request(example.metadata)
           end
 
-          it "returns a #{metadata[:response][:code]} response", rswag: true do
-            assert_response_matches_metadata(metadata.merge(options))
+          it "returns a #{metadata[:response][:code]} response", **options do
+            assert_response_matches_metadata(metadata)
             block.call(response) if block_given?
           end
         else
@@ -137,8 +139,8 @@ module Rswag
             submit_request(example.metadata)
           end
 
-          it "returns a #{metadata[:response][:code]} response", rswag: true do |example|
-            assert_response_matches_metadata(example.metadata.merge(options), &block)
+          it "returns a #{metadata[:response][:code]} response", **options do |example|
+            assert_response_matches_metadata(example.metadata, &block)
             example.instance_exec(response, &block) if block_given?
           end
         end


### PR DESCRIPTION
## Problem
It would be nice to be able to pass options to `it` through `run_test!`, such as `focus: true` like so:
```ruby
run_test! focus: true
```
This dovetails nicely with the work that is already being done to add strict schema validation.

## Solution
Pass `**options` to `it`, instead of merging it with `metadata`.